### PR TITLE
feat(dir2): aura effect — glowing color fields from flavor selections

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -14,6 +14,6 @@ describe('App mode switcher', () => {
   it('switches to aura mode on click', async () => {
     render(<App />);
     await userEvent.click(screen.getByText('Aura Effect'));
-    expect(screen.getByText('Aura Effect — coming soon')).toBeTruthy();
+    expect(screen.getByText('Select notes to build your signature')).toBeTruthy();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useTastingSession } from './hooks/useTastingSession';
 import WheelSVG from './components/WheelSVG';
+import WheelAura from './components/WheelAura';
 import type { VisualMode } from './types';
 
 const MODE_LABELS: Record<VisualMode, string> = {
@@ -39,7 +40,7 @@ export default function App() {
 
       <div style={{ border: '1px solid #eee', borderRadius: 12, padding: 32, minHeight: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {session.mode === 'wheel' && <WheelSVG session={session} onToggleNote={toggleNote} onSetGuidedStep={setGuidedStep} onSetReverseQuery={setReverseQuery} />}
-        {session.mode === 'aura' && <div style={{ color: '#999' }}>Aura Effect — coming soon</div>}
+        {session.mode === 'aura' && <WheelAura session={session} onToggleNote={toggleNote} onSetGuidedStep={setGuidedStep} onSetReverseQuery={setReverseQuery} />}
         {session.mode === 'type' && <div style={{ color: '#999' }}>Typographic Mode — coming soon</div>}
       </div>
     </div>

--- a/src/components/WheelAura/WheelAura.css
+++ b/src/components/WheelAura/WheelAura.css
@@ -1,0 +1,145 @@
+.wheel-aura {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.wheel-aura__svg {
+  display: block;
+}
+
+.wheel-aura__segment {
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+}
+
+.wheel-aura__segment:hover {
+  filter: brightness(1.2);
+}
+
+.wheel-aura__segment--selected {
+  stroke-width: 2;
+  stroke: #fff;
+}
+
+.wheel-aura__segment--dimmed {
+  opacity: 0.1;
+}
+
+.wheel-aura__family-label {
+  font-size: 10px;
+  font-weight: 600;
+  fill: #333;
+  pointer-events: none;
+  text-anchor: middle;
+  dominant-baseline: central;
+}
+
+.wheel-aura__aura-layer {
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+@keyframes aura-bloom {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+}
+
+.wheel-aura__aura-circle {
+  animation: aura-bloom 0.6s ease-out forwards;
+  transform-origin: center;
+}
+
+@keyframes pulse-match {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+.wheel-aura__segment--matching {
+  animation: pulse-match 1s infinite;
+  stroke: #fff;
+  stroke-width: 2;
+}
+
+.wheel-aura__signature {
+  width: 600px;
+  height: 80px;
+  border-radius: 8px;
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 500;
+  color: #666;
+  border: 1px solid #eee;
+  overflow: hidden;
+  position: relative;
+}
+
+.wheel-aura__signature-bar {
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+}
+
+.wheel-aura__signature-label {
+  position: relative;
+  z-index: 1;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0,0,0,0.5);
+  font-weight: 600;
+}
+
+.wheel-aura__controls {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+  width: 600px;
+}
+
+.wheel-aura__search {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 14px;
+  outline: none;
+}
+
+.wheel-aura__search:focus {
+  border-color: #2C3E50;
+}
+
+.wheel-aura__guided-tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.wheel-aura__guided-tab {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: white;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.wheel-aura__guided-tab--active {
+  background: #2C3E50;
+  color: white;
+  border-color: #2C3E50;
+}

--- a/src/components/WheelAura/WheelAura.test.tsx
+++ b/src/components/WheelAura/WheelAura.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import WheelAura from './WheelAura';
+import type { TastingSession } from '../../types';
+
+function makeSession(overrides: Partial<TastingSession> = {}): TastingSession {
+  return {
+    selectedNoteIds: [],
+    guidedStep: 'aroma',
+    reverseQuery: '',
+    mode: 'aura',
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+describe('WheelAura', () => {
+  it('renders all 9 family labels', () => {
+    render(
+      <WheelAura
+        session={makeSession()}
+        onToggleNote={noop}
+        onSetGuidedStep={noop}
+        onSetReverseQuery={noop}
+      />,
+    );
+
+    const expectedLabels = [
+      'Fruity', 'Floral', 'Sweet', 'Nutty/Cocoa',
+      'Spices', 'Roasted', 'Green/Veg', 'Other', 'Fermented',
+    ];
+
+    for (const label of expectedLabels) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('selecting a note adds an aura element to the DOM', () => {
+    const { container } = render(
+      <WheelAura
+        session={makeSession({ selectedNoteIds: ['blackberry'] })}
+        onToggleNote={noop}
+        onSetGuidedStep={noop}
+        onSetReverseQuery={noop}
+      />,
+    );
+
+    const aura = container.querySelector('[data-testid="aura-blackberry"]');
+    expect(aura).toBeInTheDocument();
+  });
+
+  it('signature bar shows "Your tasting signature" when notes are selected', () => {
+    render(
+      <WheelAura
+        session={makeSession({ selectedNoteIds: ['blackberry'] })}
+        onToggleNote={noop}
+        onSetGuidedStep={noop}
+        onSetReverseQuery={noop}
+      />,
+    );
+
+    expect(screen.getByText('Your tasting signature')).toBeInTheDocument();
+  });
+
+  it('guided step "flavor" dims fruity family', () => {
+    const { container } = render(
+      <WheelAura
+        session={makeSession({ guidedStep: 'flavor', selectedNoteIds: ['vanilla'] })}
+        onToggleNote={noop}
+        onSetGuidedStep={noop}
+        onSetReverseQuery={noop}
+      />,
+    );
+
+    const fruitySegment = container.querySelector('[data-testid="family-fruity"]');
+    expect(fruitySegment).toHaveClass('wheel-aura__segment--dimmed');
+  });
+
+  it('calls onToggleNote when a leaf note is clicked', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <WheelAura
+        session={makeSession()}
+        onToggleNote={onToggle}
+        onSetGuidedStep={noop}
+        onSetReverseQuery={noop}
+      />,
+    );
+
+    const note = container.querySelector('[data-testid="note-blackberry"]');
+    expect(note).toBeInTheDocument();
+    fireEvent.click(note!);
+    expect(onToggle).toHaveBeenCalledWith('blackberry');
+  });
+
+  it('shows empty signature message when no notes selected', () => {
+    render(
+      <WheelAura
+        session={makeSession()}
+        onToggleNote={noop}
+        onSetGuidedStep={noop}
+        onSetReverseQuery={noop}
+      />,
+    );
+
+    expect(screen.getByText('Select notes to build your signature')).toBeInTheDocument();
+  });
+});

--- a/src/components/WheelAura/WheelAura.tsx
+++ b/src/components/WheelAura/WheelAura.tsx
@@ -1,0 +1,344 @@
+import { useMemo } from 'react';
+import { FLAVOR_WHEEL, searchNotes } from '../../data/flavorWheel';
+import type { TastingSession, GuidedStep } from '../../types';
+import type { FlavorFamily } from '../../data/flavorWheel';
+import './WheelAura.css';
+
+interface WheelAuraProps {
+  session: TastingSession;
+  onToggleNote: (noteId: string) => void;
+  onSetGuidedStep: (step: GuidedStep) => void;
+  onSetReverseQuery: (q: string) => void;
+}
+
+const CX = 300;
+const CY = 300;
+const INNER_R = 100;
+const MID_R = 160;
+const OUTER_R = 220;
+const AURA_RADIUS = 120;
+
+const GUIDED_PHASES: Record<GuidedStep, string[]> = {
+  aroma: ['floral', 'fruity', 'green-vegetative', 'spices'],
+  flavor: ['sweet', 'nutty-cocoa', 'roasted', 'fermented'],
+  finish: ['other', 'roasted', 'spices'],
+};
+
+const GUIDED_LABELS: { step: GuidedStep; label: string }[] = [
+  { step: 'aroma', label: 'Aroma' },
+  { step: 'flavor', label: 'Flavor' },
+  { step: 'finish', label: 'Finish' },
+];
+
+interface ArcInfo {
+  familyId: string;
+  familyColor: string;
+  noteId: string;
+  startAngle: number;
+  endAngle: number;
+  midAngle: number;
+  midX: number;
+  midY: number;
+}
+
+function describeArc(
+  cx: number, cy: number,
+  innerR: number, outerR: number,
+  startAngle: number, endAngle: number,
+): string {
+  const startRad = (startAngle * Math.PI) / 180;
+  const endRad = (endAngle * Math.PI) / 180;
+  const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+
+  const x1o = cx + outerR * Math.cos(startRad);
+  const y1o = cy + outerR * Math.sin(startRad);
+  const x2o = cx + outerR * Math.cos(endRad);
+  const y2o = cy + outerR * Math.sin(endRad);
+  const x1i = cx + innerR * Math.cos(endRad);
+  const y1i = cy + innerR * Math.sin(endRad);
+  const x2i = cx + innerR * Math.cos(startRad);
+  const y2i = cy + innerR * Math.sin(startRad);
+
+  return [
+    `M ${x1o} ${y1o}`,
+    `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2o} ${y2o}`,
+    `L ${x1i} ${y1i}`,
+    `A ${innerR} ${innerR} 0 ${largeArc} 0 ${x2i} ${y2i}`,
+    'Z',
+  ].join(' ');
+}
+
+function computeLayout(families: FlavorFamily[]) {
+  const totalNotes = families.reduce(
+    (sum, f) => sum + f.subCategories.reduce((s, sc) => s + sc.notes.length, 0),
+    0,
+  );
+
+  const familyArcs: {
+    family: FlavorFamily;
+    startAngle: number;
+    endAngle: number;
+    midAngle: number;
+  }[] = [];
+
+  const noteArcs: ArcInfo[] = [];
+  let angle = 0;
+
+  for (const family of families) {
+    const noteCount = family.subCategories.reduce((s, sc) => s + sc.notes.length, 0);
+    const sweep = (noteCount / totalNotes) * 360;
+    const familyStart = angle;
+    const familyEnd = angle + sweep;
+
+    familyArcs.push({
+      family,
+      startAngle: familyStart,
+      endAngle: familyEnd,
+      midAngle: (familyStart + familyEnd) / 2,
+    });
+
+    let noteAngle = familyStart;
+    const noteSweep = sweep / noteCount;
+
+    for (const sub of family.subCategories) {
+      for (const note of sub.notes) {
+        const nStart = noteAngle;
+        const nEnd = noteAngle + noteSweep;
+        const midA = (nStart + nEnd) / 2;
+        const midRad = (midA * Math.PI) / 180;
+        const midR = (MID_R + OUTER_R) / 2;
+
+        noteArcs.push({
+          familyId: family.id,
+          familyColor: family.color,
+          noteId: note.id,
+          startAngle: nStart,
+          endAngle: nEnd,
+          midAngle: midA,
+          midX: CX + midR * Math.cos(midRad),
+          midY: CY + midR * Math.sin(midRad),
+        });
+
+        noteAngle = nEnd;
+      }
+    }
+
+    angle = familyEnd;
+  }
+
+  return { familyArcs, noteArcs };
+}
+
+export default function WheelAura({
+  session,
+  onToggleNote,
+  onSetGuidedStep,
+  onSetReverseQuery,
+}: WheelAuraProps) {
+  const { familyArcs, noteArcs } = useMemo(
+    () => computeLayout(FLAVOR_WHEEL),
+    [],
+  );
+
+  const matchingNoteIds = useMemo(() => {
+    if (!session.reverseQuery.trim()) return new Set<string>();
+    return new Set(searchNotes(session.reverseQuery).map(n => n.id));
+  }, [session.reverseQuery]);
+
+  const selectedSet = useMemo(
+    () => new Set(session.selectedNoteIds),
+    [session.selectedNoteIds],
+  );
+
+  const phaseFamilies = useMemo(
+    () => new Set(GUIDED_PHASES[session.guidedStep]),
+    [session.guidedStep],
+  );
+
+  const selectedFamilyColors = useMemo(() => {
+    const colors: string[] = [];
+    for (const arc of noteArcs) {
+      if (selectedSet.has(arc.noteId) && !colors.includes(arc.familyColor)) {
+        colors.push(arc.familyColor);
+      }
+    }
+    return colors;
+  }, [noteArcs, selectedSet]);
+
+  const hasGuidedActive = session.guidedStep !== 'aroma' ||
+    session.selectedNoteIds.length > 0 ||
+    session.reverseQuery.trim() !== '';
+
+  return (
+    <div className="wheel-aura">
+      <div className="wheel-aura__controls">
+        <input
+          className="wheel-aura__search"
+          type="text"
+          placeholder="Search flavors..."
+          value={session.reverseQuery}
+          onChange={e => onSetReverseQuery(e.target.value)}
+        />
+        <div className="wheel-aura__guided-tabs">
+          {GUIDED_LABELS.map(({ step, label }) => (
+            <button
+              key={step}
+              className={`wheel-aura__guided-tab${
+                session.guidedStep === step ? ' wheel-aura__guided-tab--active' : ''
+              }`}
+              onClick={() => onSetGuidedStep(step)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <svg
+        className="wheel-aura__svg"
+        viewBox="0 0 600 600"
+        width={600}
+        height={600}
+      >
+        <defs>
+          {noteArcs
+            .filter(arc => selectedSet.has(arc.noteId))
+            .map(arc => (
+              <radialGradient
+                key={`grad-${arc.noteId}`}
+                id={`aura-grad-${arc.noteId}`}
+                cx={arc.midX / 600}
+                cy={arc.midY / 600}
+                r={AURA_RADIUS / 600}
+                gradientUnits="objectBoundingBox"
+              >
+                <stop offset="0%" stopColor={arc.familyColor} stopOpacity={0.6} />
+                <stop offset="100%" stopColor={arc.familyColor} stopOpacity={0} />
+              </radialGradient>
+            ))}
+          {noteArcs
+            .filter(arc => matchingNoteIds.has(arc.noteId) && !selectedSet.has(arc.noteId))
+            .map(arc => (
+              <radialGradient
+                key={`grad-preview-${arc.noteId}`}
+                id={`aura-grad-preview-${arc.noteId}`}
+                cx={arc.midX / 600}
+                cy={arc.midY / 600}
+                r={AURA_RADIUS / 600}
+                gradientUnits="objectBoundingBox"
+              >
+                <stop offset="0%" stopColor={arc.familyColor} stopOpacity={0.3} />
+                <stop offset="100%" stopColor={arc.familyColor} stopOpacity={0} />
+              </radialGradient>
+            ))}
+        </defs>
+
+        {/* Family inner ring */}
+        {familyArcs.map(({ family, startAngle, endAngle, midAngle }) => {
+          const isDimmed = hasGuidedActive && !phaseFamilies.has(family.id);
+          const midRad = (midAngle * Math.PI) / 180;
+          const labelR = (INNER_R + MID_R) / 2;
+          const lx = CX + labelR * Math.cos(midRad);
+          const ly = CY + labelR * Math.sin(midRad);
+
+          return (
+            <g key={family.id}>
+              <path
+                className={`wheel-aura__segment${isDimmed ? ' wheel-aura__segment--dimmed' : ''}`}
+                d={describeArc(CX, CY, INNER_R, MID_R, startAngle, endAngle)}
+                fill={family.color}
+                fillOpacity={0.25}
+                stroke="#fff"
+                strokeWidth={1}
+                data-testid={`family-${family.id}`}
+              />
+              <text
+                className="wheel-aura__family-label"
+                x={lx}
+                y={ly}
+                data-testid={`family-label-${family.id}`}
+              >
+                {family.label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Leaf note outer ring */}
+        {noteArcs.map(arc => {
+          const isSelected = selectedSet.has(arc.noteId);
+          const isMatching = matchingNoteIds.has(arc.noteId) && !isSelected;
+          const isDimmed = hasGuidedActive && !phaseFamilies.has(arc.familyId);
+
+          let className = 'wheel-aura__segment';
+          if (isSelected) className += ' wheel-aura__segment--selected';
+          if (isMatching) className += ' wheel-aura__segment--matching';
+          if (isDimmed) className += ' wheel-aura__segment--dimmed';
+
+          return (
+            <path
+              key={arc.noteId}
+              className={className}
+              d={describeArc(CX, CY, MID_R, OUTER_R, arc.startAngle, arc.endAngle)}
+              fill={arc.familyColor}
+              fillOpacity={isSelected ? 1.0 : 0.25}
+              stroke={isSelected || isMatching ? '#fff' : '#fff'}
+              strokeWidth={isSelected || isMatching ? 2 : 1}
+              onClick={() => onToggleNote(arc.noteId)}
+              data-testid={`note-${arc.noteId}`}
+              style={isMatching ? { transformOrigin: `${arc.midX}px ${arc.midY}px` } : undefined}
+            />
+          );
+        })}
+
+        {/* Aura layer */}
+        <g className="wheel-aura__aura-layer">
+          {noteArcs
+            .filter(arc => selectedSet.has(arc.noteId))
+            .map(arc => (
+              <rect
+                key={`aura-${arc.noteId}`}
+                className="wheel-aura__aura-circle"
+                x={0}
+                y={0}
+                width={600}
+                height={600}
+                fill={`url(#aura-grad-${arc.noteId})`}
+                data-testid={`aura-${arc.noteId}`}
+              />
+            ))}
+          {noteArcs
+            .filter(arc => matchingNoteIds.has(arc.noteId) && !selectedSet.has(arc.noteId))
+            .map(arc => (
+              <rect
+                key={`aura-preview-${arc.noteId}`}
+                x={0}
+                y={0}
+                width={600}
+                height={600}
+                fill={`url(#aura-grad-preview-${arc.noteId})`}
+                opacity={0.3}
+              />
+            ))}
+        </g>
+      </svg>
+
+      {/* Signature panel */}
+      <div className="wheel-aura__signature" data-testid="signature-panel">
+        {selectedFamilyColors.length > 0 ? (
+          <>
+            <div
+              className="wheel-aura__signature-bar"
+              style={{
+                background: `linear-gradient(to right, ${selectedFamilyColors.join(', ')})`,
+              }}
+            />
+            <span className="wheel-aura__signature-label">Your tasting signature</span>
+          </>
+        ) : (
+          <span>Select notes to build your signature</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WheelAura/index.ts
+++ b/src/components/WheelAura/index.ts
@@ -1,0 +1,1 @@
+export { default } from './WheelAura';


### PR DESCRIPTION
## Summary
- Adds `WheelAura` component: SVG radial gradient aura layer where selected flavor notes emit soft glows in their family color
- Multiple selections blend overlapping glows via `mix-blend-mode: screen`
- Signature bar renders a live color gradient from all selected families
- All three interaction modes supported: explore (click), search (reverse lookup pulses), guided (phase dimming)
- 6 Vitest tests covering aura rendering, glow state, guided dimming, and toggle behavior

## Closes
Closes #3

## Test plan
- [ ] `npm run test` — all tests pass
- [ ] Switch to Aura Effect mode and select flavor notes — aura glows appear
- [ ] Multiple selections produce overlapping blended glows
- [ ] Signature bar fills with family colors when notes are selected
- [ ] Search input pulses matching segments
- [ ] Guided tabs dim non-phase families

🤖 Generated with [Claude Code](https://claude.com/claude-code)