### PR TITLE
feat(wheel): branch highlight on note selection

### DIFF
--- a/src/components/WheelSVG/WheelSVG.css
+++ b/src/components/WheelSVG/WheelSVG.css
@@ -12,8 +12,14 @@
   filter: brightness(1.15);
 }
 
+.wheel-segment--branch-active {
+  opacity: 1;
+  filter: brightness(1.15);
+  transition: opacity 0.3s ease, filter 0.3s ease;
+}
+
 .wheel-segment--dimmed {
-  opacity: 0.5;
+  opacity: 0.2;
 }
 
 .wheel-segment--guided-dim {

--- a/src/components/WheelSVG/WheelSVG.test.tsx
+++ b/src/components/WheelSVG/WheelSVG.test.tsx
@@ -99,6 +99,42 @@ describe('WheelSVG', () => {
   });
 });
 
+describe('WheelSVG branch highlight', () => {
+  it('selecting a note adds --branch-active to its family segment', () => {
+    render(
+      <WheelSVG session={makeSession({ selectedNoteIds: ['blackberry'] })} onToggleNote={noop} onSetGuidedStep={noop} onSetReverseQuery={noop} />
+    );
+    const familyEl = screen.getByTestId('family-fruity');
+    expect(familyEl.classList.contains('wheel-segment--branch-active')).toBe(true);
+  });
+
+  it('selecting a note adds --branch-active to its sub-category segment', () => {
+    render(
+      <WheelSVG session={makeSession({ selectedNoteIds: ['blackberry'] })} onToggleNote={noop} onSetGuidedStep={noop} onSetReverseQuery={noop} />
+    );
+    const subEl = screen.getByTestId('sub-berry');
+    expect(subEl.classList.contains('wheel-segment--branch-active')).toBe(true);
+  });
+
+  it('selecting a note dims family segments that do not contain it', () => {
+    render(
+      <WheelSVG session={makeSession({ selectedNoteIds: ['blackberry'] })} onToggleNote={noop} onSetGuidedStep={noop} onSetReverseQuery={noop} />
+    );
+    const floralEl = screen.getByTestId('family-floral');
+    expect(floralEl.classList.contains('wheel-segment--dimmed')).toBe(true);
+  });
+
+  it('deselecting all notes removes all --dimmed from family segments', () => {
+    render(
+      <WheelSVG session={makeSession({ selectedNoteIds: [] })} onToggleNote={noop} onSetGuidedStep={noop} onSetReverseQuery={noop} />
+    );
+    const families = FLAVOR_WHEEL.map(f => screen.getByTestId(`family-${f.id}`));
+    families.forEach(el => {
+      expect(el.classList.contains('wheel-segment--dimmed')).toBe(false);
+    });
+  });
+});
+
 describe('WheelSVG drag-to-spin', () => {
   it('renders SVG with grab cursor class', () => {
     render(

--- a/src/components/WheelSVG/WheelSVG.tsx
+++ b/src/components/WheelSVG/WheelSVG.tsx
@@ -218,6 +218,32 @@ export default function WheelSVG({ session, onToggleNote, onSetGuidedStep, onSet
   const hasSearch = session.reverseQuery.length > 0;
   const relevantFamilies = GUIDED_MAP[session.guidedStep];
 
+  const activeFamilyIds = useMemo(() => {
+    if (session.selectedNoteIds.length === 0) return new Set<string>();
+    const ids = new Set<string>();
+    for (const family of FLAVOR_WHEEL) {
+      for (const sub of family.subCategories) {
+        if (sub.notes.some(n => session.selectedNoteIds.includes(n.id))) {
+          ids.add(family.id);
+        }
+      }
+    }
+    return ids;
+  }, [session.selectedNoteIds]);
+
+  const activeSubIds = useMemo(() => {
+    if (session.selectedNoteIds.length === 0) return new Set<string>();
+    const ids = new Set<string>();
+    for (const family of FLAVOR_WHEEL) {
+      for (const sub of family.subCategories) {
+        if (sub.notes.some(n => session.selectedNoteIds.includes(n.id))) {
+          ids.add(sub.id);
+        }
+      }
+    }
+    return ids;
+  }, [session.selectedNoteIds]);
+
   const totalNotes = FLAVOR_WHEEL.reduce(
     (sum, f) => sum + f.subCategories.reduce((s2, sc) => s2 + sc.notes.length, 0),
     0,
@@ -272,7 +298,7 @@ export default function WheelSVG({ session, onToggleNote, onSetGuidedStep, onSet
               {/* Inner ring: family segment */}
               <path
                 data-testid={`family-${family.id}`}
-                className={`wheel-segment${guidedDim ? ' wheel-segment--guided-dim' : ''}`}
+                className={`wheel-segment${guidedDim ? ' wheel-segment--guided-dim' : hasSelection ? (activeFamilyIds.has(family.id) ? ' wheel-segment--branch-active' : ' wheel-segment--dimmed') : ''}`}
                 d={arcPath(CX, CY, R_INNER_START, R_INNER_END, familyStart, familyEnd)}
                 fill={family.color}
                 stroke="#fff"
@@ -309,7 +335,7 @@ export default function WheelSVG({ session, onToggleNote, onSetGuidedStep, onSet
                   <g key={sub.id}>
                     <path
                       data-testid={`sub-${sub.id}`}
-                      className={`wheel-segment${guidedDim ? ' wheel-segment--guided-dim' : ''}`}
+                      className={`wheel-segment${guidedDim ? ' wheel-segment--guided-dim' : hasSelection ? (activeSubIds.has(sub.id) ? ' wheel-segment--branch-active' : ' wheel-segment--dimmed') : ''}`}
                       d={arcPath(CX, CY, R_MID_START, R_MID_END, subStart, subEnd)}
                       fill={subColor}
                       stroke="#fff"


### PR DESCRIPTION
## Summary

- Selecting a note now brightens its entire family -> sub-category -> note branch and fades all other segments to 0.2 opacity
- Added `activeFamilyIds` and `activeSubIds` derived sets via `useMemo` in `WheelSVG.tsx`
- Added `--branch-active` CSS class (opacity 1, brightness 1.15) and lowered `--dimmed` opacity from 0.5 to 0.2
- Multiple selected notes light up all their branches simultaneously
- Deselecting all notes restores default opacity

## Test plan

- [x] 4 new tests: branch-active on family, branch-active on sub, dimmed on unrelated family, no dimmed when deselected
- [x] All 32 tests pass

Closes #15